### PR TITLE
Add dependency module for autotest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     apipkg
     pytest
     pytest-mock
+    pynxos
 
 commands= python setup.py test
 


### PR DESCRIPTION
netbox_netprod_importer/vendors/cisco/nxos.py:33: ModuleNotFoundError
===================== 11 failed, 15 passed in 0.68 seconds =====================
ERROR: InvocationError for command '/home/travis/build/Anthony25/netbox-netprod-importer/.tox/py36/bin/python setup.py test' (exited with code 1)