### PR TITLE
Update for netbox 2.5 cable.

### DIFF
--- a/netbox_netprod_importer/push.py
+++ b/netbox_netprod_importer/push.py
@@ -395,12 +395,9 @@ class NetboxInterconnectionsPusher(_NetboxPusher):
 
         netif_connection = None
         if netif_b.connected_endpoint:
-            connected_netif_id = int(
-                netif_b.connected_endpoint["id"]
-            )
-            if connected_netif_id == netif_a.id:
+            if netif_b.connected_endpoint.id == netif_a.id:
                 return next(self._mappers["cables"].get(
-                    netif_b.connected_endpoint["cable"]
+                    netif_b.connected_endpoint.cable.id
                 ))
             elif netif_a.connected_endpoint:
                 self._delete_connection_to_netbox_netif(netif_b)
@@ -434,9 +431,9 @@ class NetboxInterconnectionsPusher(_NetboxPusher):
                 "No connection found for network interface {}".format(netif.id)
             )
 
-        if netif.connected_endpoint.get("cable"):
+        if netif.connected_endpoint.cable.id:
             return next(self._mappers["cables"].get(
-                netif.connected_endpoint["cable"]
+                netif.connected_endpoint.cable.id
             ))
         else:
             raise ValueError(
@@ -467,11 +464,11 @@ class NetboxInterconnectionsPusher(_NetboxPusher):
         if is_macaddr(netif):
             mac_addresses = defaultdict(list)
             for i in interfaces:
-                mac_addresses[macaddr_to_int(i.mac_address)].append(i)
+                mac_addresses[macaddr_to_int(interfaces[i].mac_address)].append(interfaces[i])
 
             int_netif_mac = macaddr_to_int(netif)
-            if mac_addresses.get(int_netif_mac, 0) == 1:
-                return mac_addresses[int_netif_mac]
+            if len(mac_addresses.get(int_netif_mac, 0)) == 1:
+                return mac_addresses[int_netif_mac][0]
         else:
             for netif_deriv in self._get_all_derivatives_for_netif(netif):
                 for k in interfaces:
@@ -514,9 +511,9 @@ class NetboxInterconnectionsPusher(_NetboxPusher):
         connected in netbox (thanks to the guessing algorithms). Add in
         the `discovered` dict with the correct ones.
         """
-        netif_a = netif_conn.interface_a
+        netif_a = netif_conn.termination_a
         hostname_a = netif_a.device.name
-        netif_b = netif_conn.interface_b
+        netif_b = netif_conn.termination_b
         hostname_b = netif_b.device.name
 
         discovered[hostname_a][netif_a.name] = (hostname_b, netif_b.name)


### PR DESCRIPTION
398:403->398:400, 437->434, 439->436 - data view has changed in python-netboxapi
470->467 - "i" type is of string
473->470 - mac_addresses is an array and in Python 3.6.6 does not return the length of the array.
474->471 - Functions of this class are expected to return an interface and not an array of interfaces. 
517->514, 519->516 - netbox data structure change